### PR TITLE
Add chat detection to avoid using dash

### DIFF
--- a/cambot/wordle.py
+++ b/cambot/wordle.py
@@ -60,6 +60,24 @@ class Game:
         content = message.content.strip()
         if (len(content) >= 1 and content[0] == "-") or self.winner or not self.target: # special char, or somebody won, or never initialized
             return
+
+        # if the user is just chatting
+        if " " in content:
+            return
+        # if the guess is obviously not the same length (just chatting)
+        ratio = 2/3
+        if len(content) <= len(self.target) * ratio or len(self.target) <= len(content) * ratio:
+            return
+        # if the user post an emoji
+        if content[0] == ":":
+            return
+        # if the user post a link
+        if "://" in content:
+            return
+        # if the user post a gif (not sure about this one)
+        if len(content) == 0:
+            return
+
         guess = unidecode(content).upper()
         if WORDLE_FORCE_ALTERNATION and message.author == self.last_player:
             await self.channel.send(f"{message.author.mention} Laisse un peu jouer les autres !")


### PR DESCRIPTION
When playing, it's quite annoying to always add a dash (`-`) at the beginning of our sentences and sometimes we forget it, resulting in Cambot spamming us.

Je ne sais pas pourquoi j'écris en anglais.